### PR TITLE
Camera2D fixes

### DIFF
--- a/source/Rl.cpp.hx
+++ b/source/Rl.cpp.hx
@@ -75,7 +75,7 @@ extern class RlVector2 {
     var x:Float; // Vector x component
     var y:Float; // Vector y component
 
-    static inline function create(x:Float, y:Float):Vector2 {
+    static inline function create(x:Float, y:Float):RlVector2 {
         return untyped __cpp__("Vector2{ (Float){0}, (Float){1} }", x, y);
     }
 }
@@ -290,12 +290,12 @@ typedef Camera = Camera3D; // Camera type fallback, defaults to Camera3D
 @:structAccess
 @:unreflective
 extern class Camera2D {
-    var offset:Vector2; // Camera offset (displacement from target)
-    var target:Vector2; // Camera target (rotation and zoom origin)
+    var offset:RlVector2; // Camera offset (displacement from target)
+    var target:RlVector2; // Camera target (rotation and zoom origin)
     var rotation:Float; // Camera rotation in degrees
     var zoom:Float; // Camera zoom (scaling), should be 1.0f by default
 
-    static inline function create(offset:Vector2, target:Vector2, rotation:Float, zoom:Float):Camera2D {
+    static inline function create(offset:RlVector2, target:RlVector2, rotation:Float, zoom:Float):Camera2D {
         return untyped __cpp__("Camera2D{ (Vector2){0}, (Vector2){1}, (Float){2}, (Float){3} }", offset, target, rotation, zoom );
     }
 }

--- a/source/Rl.cpp.hx
+++ b/source/Rl.cpp.hx
@@ -295,7 +295,7 @@ extern class Camera2D {
     var rotation:Float; // Camera rotation in degrees
     var zoom:Float; // Camera zoom (scaling), should be 1.0f by default
 
-    static inline function create(offset:RlVector2, target:RlVector2, rotation:Float, zoom:Float):Camera2D {
+    static inline function create(offset:RlVector2, target:RlVector2, rotation:Float=0.0, zoom:Float=1.0):Camera2D {
         return untyped __cpp__("Camera2D{ (Vector2){0}, (Vector2){1}, (Float){2}, (Float){3} }", offset, target, rotation, zoom );
     }
 }

--- a/source/Rl.cpp.hx
+++ b/source/Rl.cpp.hx
@@ -76,7 +76,7 @@ extern class RlVector2 {
     var y:Float; // Vector y component
 
     static inline function create(x:Float, y:Float):Vector2 {
-        return untyped __cpp__("(Vector2){ (Float){0}, (Float){1} }", x, y);
+        return untyped __cpp__("Vector2{ (Float){0}, (Float){1} }", x, y);
     }
 }
 
@@ -295,8 +295,8 @@ extern class Camera2D {
     var rotation:Float; // Camera rotation in degrees
     var zoom:Float; // Camera zoom (scaling), should be 1.0f by default
 
-    static inline function create():Camera2D {
-        return untyped __cpp__("(Camera2D){ 0 }");
+    static inline function create(offset:Vector2, target:Vector2, rotation:Float, zoom:Float):Camera2D {
+        return untyped __cpp__("Camera2D{ (Vector2){0}, (Vector2){1}, (Float){2}, (Float){3} }", offset, target, rotation, zoom );
     }
 }
 


### PR DESCRIPTION
The `extern class Camera2D` is a c struct and when calling the `create` function it was being created as an empty struct and so the fields in the class were not set.

I added arguments to the `create` function so that the initial values can be passed in and the struct will not be empty.

When I was trying to set the `x` value of `target` within the `Camera2D` class I was seeing the error `base operand of ‘->’ has non-pointer type ‘Vector2‘`. The generated c code was `camera.target->x = x;` The fix for this error is usually to add `@:structAccess` to the extern binding but this was already present.

By changing the field types used in the extern bindings from `Vector2` to `RlVector2` there is no more error and the fields can be set as expected. I think this is due to `Vector2` being a typedef that wraps `RlVector2` in `cpp.Struct` which confuses matters - 

```hx
typedef Vector2 = cpp.Struct<RlVector2>;
```