### PR TITLE
Wrap aliased RlColor in cpp.Struct

### DIFF
--- a/source/Rl.cpp.hx
+++ b/source/Rl.cpp.hx
@@ -150,11 +150,12 @@ extern class RlColor {
     var a:cpp.UInt8;
 
     public static inline function create(r:cpp.UInt8, g:cpp.UInt8, b:cpp.UInt8, a:cpp.UInt8):Color {
-        return untyped __cpp__("{ (unsigned char){0}, (unsigned char){1}, (unsigned char){2}, (unsigned char){3} }", r, g, b, a);
+        // return untyped __cpp__("Color { (unsigned char){0}, (unsigned char){1}, (unsigned char){2}, (unsigned char){3} }", r, g, b, a);
+        return untyped __cpp__(" { (unsigned char){0}, (unsigned char){1}, (unsigned char){2}, (unsigned char){3} }", r, g, b, a);
     }
 }
 
-typedef Color = RlColor;
+typedef Color = cpp.Struct<RlColor>;
 
 // Rectangle, 4 components
 @:include("raylib.h")


### PR DESCRIPTION
I was seeing `error: cannot convert ‘Dynamic’ to ‘Color’` when passing a `Color` as a constructor argument.

A helpful bit of info from the haxe discord -

> constructor arguments must be "dynamic compatible" on hxcpp which externs representing native structs won't be, try wrapping the struct in a cpp.Struct for the constructor argument

This explains why there are lots of this in the bindings -  
```hx
typedef Foo = cpp.Struct<Bar>;
```

e.g. as seen in the commit, this allows `Color` to be passed as a constructor argument - 
```hx
typedef Color = cpp.Struct<RlColor>;
```

