### PR TITLE
Added an option to use system-wide installations on linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,13 @@ class Main {
     Rl.closeWindow();
   }
 }
-
 ```
+
+On Linux it's possible to use a system wide installation of Raylib instead of
+the source code provided with this repo.
+
+Just add the `--define shared_libs` flag to your *.hxml file or to the command
+line.
 
 Thanks to:
 ----------

--- a/source/DynLib.xml
+++ b/source/DynLib.xml
@@ -1,0 +1,14 @@
+<xml>
+    <error value="Dynamic linking (shared libraries) not supported for this OS" unless="linux"/>
+
+    <files id="haxe" if="linux">
+        <compilerflag value="-I/usr/include"/>
+        <compilerflag value="-L/usr/lib"/>
+        <compilerflag value="-L/usr/lib64"/>
+    </files>
+    
+    <target id="haxe" tool="linker" if="linux">
+        <flag value="-lraylib"/>
+        <flag value="-lraygui"/>
+    </target>
+</xml>

--- a/source/Rl.cpp.hx
+++ b/source/Rl.cpp.hx
@@ -1319,6 +1319,8 @@ extern enum abstract NPatchLayout(UInt) {
 
 #if wasm
 @:buildXml("<include name='${haxelib:raylib-hx}/source/Web.xml'/>")
+#elseif shared_libs
+@:buildXml("<include name='${haxelib:raylib-hx}/source/DynLib.xml'/>")
 #else
 @:buildXml("<include name='${haxelib:raylib-hx}/source/Build.xml'/>")
 #end


### PR DESCRIPTION
This lets Linux devs use a system-wide installation of raylib instead of using the bundled version via a hxml flag.