### PR TITLE
Disable console window by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ the source code provided with this repo.
 Just add the `--define shared_libs` flag to your *.hxml file or to the command
 line.
 
-To enable the Raylib console window on desktop, add the `--define show-console` flag.
+To hide the Raylib console window on desktop, add the `--define hide-console` flag.
 
 ### Consider supporting
 [![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/W7W77EX85)

--- a/README.md
+++ b/README.md
@@ -54,5 +54,7 @@ the source code provided with this repo.
 Just add the `--define shared_libs` flag to your *.hxml file or to the command
 line.
 
+To enable the Raylib console window on desktop, add the `--define show-console` flag.
+
 ### Consider supporting
 [![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/W7W77EX85)

--- a/source/Build.xml
+++ b/source/Build.xml
@@ -12,8 +12,8 @@
             <compilerflag value="-DSUPPORT_FILEFORMAT_BMP" unless="raylib-no-bmp" />
             <compilerflag value="-DSUPPORT_FILEFORMAT_TGA" unless="raylib-no-tga" />
 
-            <flag value="-mwindows" unless="raylib-show-console" />
-            
+            <flag value="-mwindows" unless="show-console" />
+
             <file name="${raylib_folder}/rcore.c" />
             <file name="${raylib_folder}/utils.c" />
             <file name="${raylib_folder}/rshapes.c" />

--- a/source/Build.xml
+++ b/source/Build.xml
@@ -11,6 +11,9 @@
             <compilerflag value="-DSUPPORT_FILEFORMAT_JPG" unless="raylib-no-jpg" />
             <compilerflag value="-DSUPPORT_FILEFORMAT_BMP" unless="raylib-no-bmp" />
             <compilerflag value="-DSUPPORT_FILEFORMAT_TGA" unless="raylib-no-tga" />
+
+            <compilerflag value="-Wl" unless="raylib-show-console" />
+            <compilerflag value="--subsystem,windows" unless="raylib-show-console" />
             
             <file name="${raylib_folder}/rcore.c" />
             <file name="${raylib_folder}/utils.c" />

--- a/source/Build.xml
+++ b/source/Build.xml
@@ -12,8 +12,7 @@
             <compilerflag value="-DSUPPORT_FILEFORMAT_BMP" unless="raylib-no-bmp" />
             <compilerflag value="-DSUPPORT_FILEFORMAT_TGA" unless="raylib-no-tga" />
 
-            <compilerflag value="-Wl" unless="raylib-show-console" />
-            <compilerflag value="--subsystem,windows" unless="raylib-show-console" />
+            <flag value="-mwindows" unless="raylib-show-console" />
             
             <file name="${raylib_folder}/rcore.c" />
             <file name="${raylib_folder}/utils.c" />

--- a/source/Build.xml
+++ b/source/Build.xml
@@ -12,7 +12,7 @@
             <compilerflag value="-DSUPPORT_FILEFORMAT_BMP" unless="raylib-no-bmp" />
             <compilerflag value="-DSUPPORT_FILEFORMAT_TGA" unless="raylib-no-tga" />
 
-            <flag value="-mwindows" unless="show-console" />
+            <flag value="-mwindows" if="hide-console" />
 
             <file name="${raylib_folder}/rcore.c" />
             <file name="${raylib_folder}/utils.c" />


### PR DESCRIPTION
The Raylib console window is now hidden by default.
To enable it, you can add a flag, as explained in the README.