### PR TITLE
add raygui submodule and include

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "source/lib"]
 	path = source/lib
 	url = https://github.com/raysan5/raylib
+[submodule "source/raygui"]
+	path = source/raygui
+	url = https://github.com/raysan5/raygui.git

--- a/source/Build.xml
+++ b/source/Build.xml
@@ -1,12 +1,16 @@
 <xml>
     <set name="raylib_folder" value="${haxelib:raylib-hx}/source/lib/src" />
     <set name="glfw_folder" value="${haxelib:raylib-hx}/source/lib/src/external/glfw" />
+    <set name="raygui_folder" value="${haxelib:raylib-hx}/source/raygui/src" />
 
     <section>
         <files id="haxe">
             <compilerflag value="-I${glfw_folder}/include" />
             <compilerflag value="-I${raylib_folder}" />
             <compilerflag value="-I${raylib_folder}/extras" />
+            
+            <compilerflag value="-I${raygui_folder}" />
+            <compilerflag value="-DRAYGUI_IMPLEMENTATION" />
 
             <compilerflag value="-DSUPPORT_FILEFORMAT_JPG" unless="raylib-no-jpg" />
             <compilerflag value="-DSUPPORT_FILEFORMAT_BMP" unless="raylib-no-bmp" />
@@ -20,7 +24,6 @@
             <file name="${raylib_folder}/rmodels.c" />
             <file name="${raylib_folder}/raudio.c" />
             <file name="${raylib_folder}/rglfw.c" />
-            <!-- <file name="${haxelib:raylib-hx}/source/raygui.c" /> -->
         </files>
 
         <!-- WINDOWS COMPILER -->

--- a/source/Web.xml
+++ b/source/Web.xml
@@ -1,6 +1,7 @@
 <xml>
     <set name="raylib_folder" value="${haxelib:raylib-hx}/source/lib/src" />
     <set name="glfw_folder" value="${haxelib:raylib-hx}/source/lib/src/external/glfw" />
+    <set name="raygui_folder" value="${haxelib:raylib-hx}/source/raygui/src" />
 
     <echo value="Using raylib from: ${raylib_folder}" />
     <echo value="Using glfw from: ${glfw_folder}" />
@@ -13,7 +14,10 @@
 
             <compilerflag value="-I${raylib_folder}" />
             <compilerflag value="-I${raylib_folder}/extras" />
-            
+
+            <compilerflag value="-I${raygui_folder}" />
+            <compilerflag value="-DRAYGUI_IMPLEMENTATION" />
+
             <file name="${raylib_folder}/rcore.c" />
             <file name="${raylib_folder}/utils.c" />
             <file name="${raylib_folder}/rshapes.c" />
@@ -21,7 +25,6 @@
             <file name="${raylib_folder}/rtext.c" />
             <file name="${raylib_folder}/rmodels.c" />
             <file name="${raylib_folder}/raudio.c" />
-            <!-- <file name="${haxelib:raylib-hx}/source/raygui.c" /> -->
 
             <!-- WEB SPECIFICS -->
             <compilerflag value="-DPLATFORM_WEB" />

--- a/source/raygui.c
+++ b/source/raygui.c
@@ -1,2 +1,0 @@
-// #define RAYGUI_IMPLEMENTATION
-// #include "raygui.h"


### PR DESCRIPTION
This adds the raygui repo as a submodule and includes the relevant folder in build.xml.

Also defines RAYGUI_IMPLEMENTATION in the xml so `source/raygui.c` is no longer needed.